### PR TITLE
devices: convert user specified device into lowercase

### DIFF
--- a/tg_bot/modules/device.py
+++ b/tg_bot/modules/device.py
@@ -16,7 +16,7 @@ def device(bot: Bot, update: Update):
     data = json.loads(url.read().decode())
 
   message = update.effective_message
-  text = message.text[len('/device '):].strip()
+  text = message.text[len('/device '):].strip().lower()
   try:
     deviceinfo = data[text]
   except: 


### PR DESCRIPTION
When a user specifies a device with an uppercase letter (e.g., /device
Mido), it'll tell the user that the device Mido isn't official, since
none of our devices have uppercase letters in the json. To fix this and
avoid confusion, convert the specified device to lowercase.

Signed-off-by: shagbag913 <sh4gbag913@gmail.com>